### PR TITLE
Improve Skopea Task to accept a components array to reduce noise in pipeline spec

### DIFF
--- a/charts/tekton/charts/deploy-release/templates/pipeline.yaml
+++ b/charts/tekton/charts/deploy-release/templates/pipeline.yaml
@@ -18,31 +18,14 @@ spec:
   workspaces:
     - name: source-pvc
   tasks:
-    - name: skopeo-frontend
-      when:
-        - input: "frontend"
-          operator: in
-          values: ["$(params.COMPONENTS[*])"]
-        # - cel: "'frontend' in '$(params.COMPONENTS[*])'"
+    - name: copy-images
       params:
-        - name: SOURCE
-          value: {{ .Values.frontend.imageName }}:$(params.IMAGE_TAG)
-        - name: DESTINATION
-          value: {{ .Values.frontend.imageName }}:$(params.VERSION)
-      taskRef:
-        kind: Task
-        name: skopeo
-    - name: skopeo-backend
-      when:
-        - input: "backend"
-          operator: in
-          values: ["$(params.COMPONENTS[*])"]
-        # - cel: "'backend' in '$(params.COMPONENTS[*])'"
-      params:
-        - name: SOURCE
-          value: {{ .Values.backend.imageName }}:$(params.IMAGE_TAG)
-        - name: DESTINATION
-          value: {{ .Values.backend.imageName }}:$(params.VERSION)
+        - name: COMPONENTS
+          value: $(params.COMPONENTS[*])
+        - name: SOURCE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: DESTINATION_TAG
+          value: $(params.VERSION)
       taskRef:
         kind: Task
         name: skopeo

--- a/charts/tekton/charts/deploy-release/templates/skopeo.yaml
+++ b/charts/tekton/charts/deploy-release/templates/skopeo.yaml
@@ -8,15 +8,41 @@ spec:
   description: >-
     Copy an image (manifest, filesystem layers, signatures) from one location to another.
   params:
-    - name: SOURCE
+    - name: COMPONENTS
+      type: array
+      description: List of components to be copied. Image names will be derived from the values file.
+    - name: SOURCE_TAG
       type: string
-      description: Image with tag to copy
-    - name: DESTINATION
+      description: Image tag to copy
+    - name: DESTINATION_TAG
       type: string
-      description: Destination of copied image with image name and tag
+      description: Destination tag of copied image
+  volumes:
+    - name: result-share
+      emptyDir: {}
   steps:
+    - name: map-image-names
+      image: alpine
+      volumeMounts:
+        - name: result-share
+          mountPath: /tmp/image-names
+      args: ["$(params.COMPONENTS[*])"]
+      script: |
+        #!/bin/sh
+        set -e
+
+        for component in ${@}; do
+          if [[ "$component" == "frontend" ]]; then
+            echo "{{ .Values.frontend.imageName }}" >> /tmp/image-names/image-names.txt
+          elif [[ "$component" == "backend" ]]; then
+            echo "{{ .Values.backend.imageName }}" >> /tmp/image-names/image-names.txt
+          fi
+        done
     - name: copy
       image: quay.io/skopeo/stable:latest
+      volumeMounts:
+        - name: result-share
+          mountPath: /tmp/image-names
       env:
         - name: REGISTRY_USERNAME
           valueFrom:
@@ -32,7 +58,12 @@ spec:
         #!/bin/sh
         set +x
 
-        skopeo copy \
-          --src-creds "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" \
-          --dest-creds "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" \
-          docker://$(params.SOURCE) docker://$(params.DESTINATION)
+        IMAGE_NAMES=$(cat /tmp/image-names/image-names.txt)
+
+        for image in $IMAGE_NAMES; do
+          echo "Copying $image from $(params.SOURCE_TAG) to $(params.DESTINATION_TAG)"
+          skopeo copy \
+            --src-creds "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" \
+            --dest-creds "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" \
+            docker://$image:$(params.SOURCE_TAG) docker://$image:$(params.DESTINATION_TAG)
+        done


### PR DESCRIPTION
This pull request includes changes to the "deploy-release" pipeline and Skopeo task templates to improve the handling of image copying for multiple components. The most important changes include consolidating tasks, updating parameters, and enhancing the Skopeo task to handle multiple components dynamically.

Improvements to Tekton pipeline:

* [`charts/tekton/charts/deploy-release/templates/pipeline.yaml`](diffhunk://#diff-c97e8d67b85e81c867909c20aed7248e2b85579028f96a7192b0f9440f52a4c3L21-R28): Consolidated the `skopeo-frontend` and `skopeo-backend` tasks into a single `copy-images` task. Updated parameters to handle multiple components dynamically.

Enhancements to Skopeo task:

* [`charts/tekton/charts/deploy-release/templates/skopeo.yaml`](diffhunk://#diff-7d08ef33ae8acbb870b62447a857c5079e27d6de74aba0d338a977d12b7f928cL11-R45): Added new parameters `COMPONENTS`, `SOURCE_TAG`, and `DESTINATION_TAG`. Introduced a step to map component names to image names based on the values file.
* [`charts/tekton/charts/deploy-release/templates/skopeo.yaml`](diffhunk://#diff-7d08ef33ae8acbb870b62447a857c5079e27d6de74aba0d338a977d12b7f928cR61-R69): Modified the `copy` step to read image names from a temporary file and loop through them to perform the copy operation for each component.